### PR TITLE
Add test for lazy-import with broken path

### DIFF
--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -182,7 +182,7 @@ suite('Analyzer', () => {
 
         let errorCounter = 0;
         const errorListener = (err: Error) => {
-          assert.equal(err.message, '2 error(s) occurred during build.');
+          assert.equal(err.message, '3 error(s) occurred during build.');
           errorCounter++;
           if (errorCounter >= 2) {
             done();

--- a/test-fixtures/bad-src-import/src/a.html
+++ b/test-fixtures/bad-src-import/src/a.html
@@ -1,3 +1,4 @@
 <link rel="import" href="../dependencies/dep-1.html">
 <link rel="import" href="broken-path/to-missing-file-in-src-directory.html">
 <link rel="import" href="broken-path/to-another-missing-file-in-src-directory.html">
+<link rel="lazy-import" href="broken-path/to-lazy-missing-file-in-src-directory.html">


### PR DESCRIPTION
Seems to be working fine now, updated test passing locally at least.

Nice work, here's a `lazy-import` test PR!